### PR TITLE
Update README.md to mention the AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ I reccomend a vim package manager:
 - [pathogen.vim](https://github.com/tpope/vim-pathogen):
 - [neobunlde](https://github.com/Shougo/neobundle.vim)
 
+Alternatively, if you use Arch Linux you can install [vim-jq-git](https://aur.archlinux.org/packages/vim-jq-git/) from the Arch User Repository.
+
 ### Confugrations
 
 To disable number highlighting add `hi link jqNumber Normal` to your vimrc


### PR DESCRIPTION
I user Arch Linux and I don't like messing with Vim plugin managers, especially for simple plugins like for syntax highlighting. So I packaged your software for Arch Linux and submitted it to the Arch User Repository. You can see it here: [https://aur.archlinux.org/packages/vim-jq-git/](https://aur.archlinux.org/packages/vim-jq-git/)

This PR updates the README.md to mention that there exists a package for this plugin in the Arch User Repository.